### PR TITLE
Added support for Ryzen 9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TARGET	        := $(shell uname -r)
-DKMS_ROOT_PATH  := /usr/src/zenpower-0.1.1
+DKMS_ROOT_PATH  := /usr/src/zenpower-0.1.2
 
 ifneq ("","$(wildcard /usr/src/linux-headers-$(TARGET)/*)")
 # Ubuntu
@@ -31,10 +31,10 @@ dkms-install:
 	cp $(CURDIR)/dkms.conf $(DKMS_ROOT_PATH)
 	cp $(CURDIR)/Makefile $(DKMS_ROOT_PATH)
 	cp $(CURDIR)/zenpower.c $(DKMS_ROOT_PATH)
-	dkms add zenpower/0.1.1
-	dkms build zenpower/0.1.1
-	dkms install zenpower/0.1.1
+	dkms add zenpower/0.1.2
+	dkms build zenpower/0.1.2
+	dkms install zenpower/0.1.2
 
 dkms-uninstall:
-	dkms remove zenpower/0.1.1 --all
+	dkms remove zenpower/0.1.2 --all
 	rm -rf $(DKMS_ROOT_PATH)

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,7 +1,7 @@
 MAKE="make TARGET=${kernelver}"
 CLEAN="make clean"
 PACKAGE_NAME="zenpower"
-PACKAGE_VERSION="0.1.1"
+PACKAGE_VERSION="0.1.2"
 BUILT_MODULE_NAME[0]="zenpower"
 DEST_MODULE_LOCATION[0]="/kernel/drivers/hwmon/zenpower"
 AUTOINSTALL="yes"

--- a/zenpower.c
+++ b/zenpower.c
@@ -32,6 +32,10 @@ MODULE_LICENSE("GPL");
 #define PCI_DEVICE_ID_AMD_17H_M30H_DF_F3	0x1493
 #endif
 
+#ifndef PCI_DEVICE_ID_AMD_17H_M70H_DF_F3
+#define PCI_DEVICE_ID_AMD_17H_M70H_DF_F3 	0x1443
+#endif
+
 /* F17h M01h Access througn SMN */
 #define F17H_M01H_REPORTED_TEMP_CTRL_OFFSET	0x00059800
 #define F17H_M01H_SVI	                    0x0005A000
@@ -320,6 +324,7 @@ static const struct pci_device_id zenpower_id_table[] = {
 	{ PCI_VDEVICE(AMD, PCI_DEVICE_ID_AMD_17H_DF_F3) },
 	{ PCI_VDEVICE(AMD, PCI_DEVICE_ID_AMD_17H_M10H_DF_F3) },
 	{ PCI_VDEVICE(AMD, PCI_DEVICE_ID_AMD_17H_M30H_DF_F3) },
+	{ PCI_VDEVICE(AMD, PCI_DEVICE_ID_AMD_17H_M70H_DF_F3) },
 	{}
 };
 MODULE_DEVICE_TABLE(pci, zenpower_id_table);


### PR DESCRIPTION
For the 3900x I needed additional IDs for zenpower to work.

The following kernel patch is also needed: 
https://patchwork.kernel.org/patch/11043277/