### PR TITLE
Added KERNEL_MODULES variable to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ VERSION         := 0.1.4
 TARGET          := $(shell uname -r)
 DKMS_ROOT_PATH  := /usr/src/zenpower-$(VERSION)
 
+KERNEL_MODULES	:= /lib/modules/$(TARGET)
+
 ifneq ("","$(wildcard /usr/src/linux-headers-$(TARGET)/*)")
 # Ubuntu
 KERNEL_BUILD	:= /usr/src/linux-headers-$(TARGET)


### PR DESCRIPTION
Without it, systems with kernels that don't use Ubuntu's or Fedora's kernel locations will default to '/build'.