### PR TITLE
minor improvements to the Makefile target "dkms-install"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ clean:
 	@$(MAKE) -C $(KERNEL_BUILD) M=$(CURDIR) clean
 
 dkms-install:
+	dkms --version >> /dev/null
 	mkdir -p $(DKMS_ROOT_PATH)
 	cp $(CURDIR)/dkms.conf $(DKMS_ROOT_PATH)
 	cp $(CURDIR)/Makefile $(DKMS_ROOT_PATH)

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ clean:
 	@$(MAKE) -C $(KERNEL_BUILD) M=$(CURDIR) clean
 
 dkms-install:
-	mkdir $(DKMS_ROOT_PATH)
+	mkdir -p $(DKMS_ROOT_PATH)
 	cp $(CURDIR)/dkms.conf $(DKMS_ROOT_PATH)
 	cp $(CURDIR)/Makefile $(DKMS_ROOT_PATH)
 	cp $(CURDIR)/zenpower.c $(DKMS_ROOT_PATH)


### PR DESCRIPTION
I just attempted to install it after a fresh minimal install of ubuntu 20.04, then of course it failed due to no `dkms`.
After installing `dkms` via package manager, it failed again due to `mkdir`'ing an existing path, which was the residue from the last unsuccessful attempt. 

Suggesting to make changes so that:

1. add `-p` arg to `mkdir` so that it doesn't fail if the path exists already 
2. test the `dkms` availability before any action in the `dkms-install` target, so that it will neither create directory nor copy those paths if `dkms` is unavailable.  